### PR TITLE
syntax highlighting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "mdformat>=0.7.22",
     "mistune>=3.1.3",
     "pydantic>=2.10.6",
+    "pygments>=2.19.1",
     "python-dateutil>=2.9.0.post0",
     "python-dotenv>=1.1.0",
     "python-frontmatter>=1.1.0",
@@ -89,6 +90,7 @@ dev = [
     "mypy>=1.15.0",
     "pre-commit>=4.2.0",
     "ruff>=0.11.0",
+    "types-pygments>=2.19.0.20250305",
     "types-python-dateutil>=2.9.0.20241206",
     "types-toml>=0.10.8.20240310",
 ]

--- a/src/blogtuner/markdown.py
+++ b/src/blogtuner/markdown.py
@@ -1,0 +1,34 @@
+import mdformat
+import mistune
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import get_lexer_by_name
+from pygments.styles import get_style_by_name
+
+
+css_styles = HtmlFormatter().get_style_defs(".highlight")
+
+
+class HighlightRenderer(mistune.HTMLRenderer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, escape=False)
+
+    def block_code(self, code, info=None):
+        if not info:
+            return f"\n<pre>{mistune.escape(code)}</pre>\n"
+        lexer = get_lexer_by_name(info, stripall=True)
+        formatter = HtmlFormatter(
+            linenos=True, cssclass="highlight", style=get_style_by_name("lightbulb")
+        )
+        return highlight(code, lexer, formatter)
+
+
+renderer = HighlightRenderer()
+to_html = mistune.create_markdown(
+    renderer=renderer,
+    escape=False,
+    plugins=["strikethrough", "footnotes", "table", "speedup"],
+)
+
+
+format_markdown = mdformat.text

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "blogtuner"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "feedgen" },
@@ -23,6 +23,7 @@ dependencies = [
     { name = "mdformat" },
     { name = "mistune" },
     { name = "pydantic" },
+    { name = "pygments" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "python-frontmatter" },
@@ -36,6 +37,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "types-pygments" },
     { name = "types-python-dateutil" },
     { name = "types-toml" },
 ]
@@ -49,6 +51,7 @@ requires-dist = [
     { name = "mdformat", specifier = ">=0.7.22" },
     { name = "mistune", specifier = ">=3.1.3" },
     { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pygments", specifier = ">=2.19.1" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
@@ -62,6 +65,7 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ruff", specifier = ">=0.11.0" },
+    { name = "types-pygments", specifier = ">=2.19.0.20250305" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20241206" },
     { name = "types-toml", specifier = ">=0.10.8.20240310" },
 ]
@@ -873,6 +877,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+]
+
+[[package]]
+name = "types-docutils"
+version = "0.21.0.20241128"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/df/64e7ab01a4fc5ce46895dc94e31cffc8b8087c8d91ee54c45ac2d8d82445/types_docutils-0.21.0.20241128.tar.gz", hash = "sha256:4dd059805b83ac6ec5a223699195c4e9eeb0446a4f7f2aeff1759a4a7cc17473", size = 26739 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/b6/10ba95739f2cbb9c5bd2f6568148d62b468afe01a94c633e8892a2936d8a/types_docutils-0.21.0.20241128-py3-none-any.whl", hash = "sha256:e0409204009639e9b0bf4521eeabe58b5e574ce9c0db08421c2ac26c32be0039", size = 34677 },
+]
+
+[[package]]
+name = "types-pygments"
+version = "2.19.0.20250305"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-docutils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/be/88f777c75022b111f9e9fe4cdb430bf92892fe90188b0fd037601ded2ea1/types_pygments-2.19.0.20250305.tar.gz", hash = "sha256:044c50e80ecd4128c00a7268f20355e16f5c55466d3d49dfda09be920af40b4b", size = 18521 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/c6/b6d3ad345b76425e46d25a2da1758603d80c3a59405bdcbbbaa86d8c8070/types_pygments-2.19.0.20250305-py3-none-any.whl", hash = "sha256:ca88aae5ec426f9b107c0f7adc36dc096d2882d930a49f679eaf4b8b643db35d", size = 25638 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes changes to add syntax highlighting to the markdown rendering and update the dependencies accordingly. The most important changes include importing and using the `pygments` library, updating the `pyproject.toml` dependencies, and modifying the markdown processing logic.

### Syntax highlighting and markdown processing:

* [`src/blogtuner/markdown.py`](diffhunk://#diff-68638a2cd59b6db1a4d967275e14fd0d61df1c17576af03b9c810c55d092257eR1-R34): Added imports for `mdformat`, `mistune`, and `pygments`, and created a new `HighlightRenderer` class to handle syntax highlighting. Also defined `to_html` and `format_markdown` functions for rendering markdown to HTML and formatting markdown text respectively.

* [`src/blogtuner/models.py`](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL10-R19): Updated the import statements to include the new markdown processing functions and CSS styles. Modified the `html_content` property to use `to_html` for rendering markdown content as HTML. Updated the `from_markdown_file` method to use `format_markdown` for formatting markdown content. [[1]](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL10-R19) [[2]](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL97-R96) [[3]](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL114) [[4]](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL137-R135)

### Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R16): Added `pygments>=2.19.1` to the main dependencies and `types-pygments>=2.19.0.20250305` to the development dependencies. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R16) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R93)

### Asset management:

* [`src/blogtuner/models.py`](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdR353-R354): Updated the `copy_assets` method to include writing the `css_styles` to an `extra.css` file in the target directory.