### PR TITLE
allow for original url to be displayed

### DIFF
--- a/src/blogtuner/data/templates/post.html.jinja
+++ b/src/blogtuner/data/templates/post.html.jinja
@@ -28,8 +28,25 @@
     class="prose prose-lg max-w-none dark:prose-invert mb-10 leading-normal prose-h1:text-3xl prose-headings:text-gray-500">
     {{ post.html_content |safe }}
   </article>
-  {%- if post.tags %}
   <footer class="border-t border-gray-200 pt-6 mt-10">
+    {% if post.original_href %}
+    <div class="mb-6">
+      <h2 class="text-lg font-semibold mb-2">Originally published</h2>
+      <div class="text-gray-600">
+        <a href="{{ post.original_href }}" class="text-blue-600 hover:text-blue-800 transition-colors duration-200"
+          target="_blank" rel="noopener">
+          {{ post.original_href }}
+        </a>
+        {% if post.original_pubdate %}
+        <div class="mt-1">
+          <time datetime="{{ post.original_pubdate|date('%Y-%m-%d') }}">{{ post.original_pubdate|date('%B %d, %Y')
+            }}</time>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+    {%- if post.tags %}
     <div class="mb-6">
       <h2 class="text-lg font-semibold mb-2">Tags</h2>
       <ul class="flex flex-wrap gap-2">
@@ -38,8 +55,8 @@
         {% endfor %}
       </ul>
     </div>
+    {% endif %}
   </footer>
-  {% endif %}
 </article>
 <nav class="max-w-3xl mx-auto mt-10 pt-6 border-t border-gray-200">
   <p>

--- a/src/blogtuner/models.py
+++ b/src/blogtuner/models.py
@@ -12,7 +12,7 @@ from dateutil import tz
 from dateutil.parser import parse as dateparse
 from feedgen.feed import FeedGenerator  # type: ignore
 from loguru import logger
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl, field_serializer
 from slugify import slugify
 
 from .constants import DEFAULT_BLOG_METADATA, DEFAULT_POST_METADATA
@@ -66,6 +66,15 @@ class BlogPost(BaseModel):
     tags: List[str] = []
     oneliner: Optional[str] = None
     thumbnail: Optional[str] = None
+
+    # Original publication
+    original_href: Optional[HttpUrl] = None
+    original_pubdate: Optional[dt.datetime] = None
+
+    @field_serializer("original_href")
+    def serialize_original_href(self, value: Optional[HttpUrl]) -> Optional[str]:
+        """Serialize original_href to a string."""
+        return str(value) if value else None
 
     @property
     def short_date(self) -> str:


### PR DESCRIPTION
This pull request includes changes to the `blogtuner` project, focusing on enhancing the display of original publication information for blog posts and making minor improvements to the model serialization. The most important changes include adding fields for the original publication URL and date, updating the HTML template to show this information, and adding a serializer for the new field.

Enhancements to blog post display:

* [`src/blogtuner/data/templates/post.html.jinja`](diffhunk://#diff-7245a892d972088d72bf679cf5c74c5252539bb0481fa6c6eea93773daa0a92eL31-R49): Added a section to display the original publication URL and date if available. This includes new HTML elements and conditional logic to handle the display. [[1]](diffhunk://#diff-7245a892d972088d72bf679cf5c74c5252539bb0481fa6c6eea93773daa0a92eL31-R49) [[2]](diffhunk://#diff-7245a892d972088d72bf679cf5c74c5252539bb0481fa6c6eea93773daa0a92eL41-R59)

Model improvements:

* [`src/blogtuner/models.py`](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL15-R15): Added `original_href` and `original_pubdate` fields to the `BlogPost` model to store the original publication URL and date. Also, added a `field_serializer` for `original_href` to ensure it is serialized as a string. [[1]](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL15-R15) [[2]](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdR70-R78)