### PR TITLE
add ability to sort pinned posts

### DIFF
--- a/src/blogtuner/data/templates/list.html.jinja
+++ b/src/blogtuner/data/templates/list.html.jinja
@@ -18,7 +18,7 @@
     {%- for post in blog.sorted_public_posts %}
     <li class="flex items-start border-b border-gray-200 pb-6">
       <div class="flex-1 pr-6">
-        <h2 class="text-xl font-semibold mb-2">
+        <h2 class="text-xl font-semibold mb-2">{% if post.pinned %}📌 {% endif %}
           <a href="{{ blog.base_path }}{{ post.html_filename }}"
             class="hover:text-blue-600 transition-colors duration-200">
             {{ post.title }}

--- a/src/blogtuner/models.py
+++ b/src/blogtuner/models.py
@@ -116,6 +116,9 @@ class BlogPost(BaseModel):
     # Post images
     image: Optional[Image] = None
 
+    # Pinning (pinned posts will be displayed first)
+    pinned: bool = False
+
     # Extra metadata fields
     tags: List[str] = []
     oneliner: Optional[str] = None
@@ -373,9 +376,14 @@ class BlogConfig(BaseModel):
 
     @cached_property
     def sorted_public_posts(self) -> List[BlogPost]:
-        """Get public posts sorted by date descending."""
+        """Get public posts sorted by pinned status first, then by date descending."""
+        publishable_posts = self.get_publishable_posts()
         return sorted(
-            self.get_publishable_posts(), key=lambda post: post.pubdate, reverse=True
+            publishable_posts,
+            key=lambda post: (
+                not getattr(post, "pinned", False),
+                -post.pubdate.timestamp(),
+            ),
         )
 
 


### PR DESCRIPTION
This pull request introduces a feature to pin blog posts, ensuring that pinned posts are displayed first on the blog. The changes span across the template for listing posts, the blog post model, and the method for sorting posts.

### Pinning Feature:

* [`src/blogtuner/data/templates/list.html.jinja`](diffhunk://#diff-9c3250feabb2ab6872438d7746cf309fa080f3d1a4c02895f55f87a41d0a19cdL21-R21): Added a pin icon next to the title of pinned posts in the blog post list.
* [`src/blogtuner/models.py`](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdR119-R121): Added a `pinned` attribute to the `BlogPost` model to indicate if a post is pinned.
* [`src/blogtuner/models.py`](diffhunk://#diff-f74c5e7a76fe8ee2382aea3566fef41520d56aeffba9bc3b7997558e339210cdL376-R386): Modified the `sorted_public_posts` method to sort posts by pinned status first, followed by publication date.